### PR TITLE
Fix Bug commit

### DIFF
--- a/src/stores/todo.ts
+++ b/src/stores/todo.ts
@@ -61,6 +61,7 @@ export const useTodoStore = defineStore("counter", () => {
 
   function clearCompletedTodos() {
     todos.value = todos.value.filter((todo) => todo.isCompleted === false);
+    updateLocalStorage();
   }
 
   return {


### PR DESCRIPTION
When we call clearCompletedTodos() function delete todos.isCompleted = false item but when restart page we see its item because this function don't update localStorage data so i add this line...